### PR TITLE
Adding a setLang option to the Client.

### DIFF
--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -225,4 +225,16 @@ class ClientSpec extends ObjectBehavior
 
         expect($http->getRequests())->toHaveCount(2);
     }
+
+    public function it_uses_the_lang_parameter() {
+        $this->setLang("fr");
+        $url = $this->buildUrl("/items/123")->getWrappedObject()->__toString();
+        expect($url)->shouldEndWith("&lang=fr");
+    }
+
+    public function it_does_not_use_empty_lang_parameter() {
+        $url = $this->buildUrl("/items/123")->getWrappedObject()->__toString();
+        expect($url)->shouldNotContain("&lang=");
+        print_r($url);
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -49,6 +49,9 @@ class Client
     /** @var string Alma Developers Network API key for this zone */
     public $key;
 
+    /** @var string default language for API results */
+    public $lang;
+
     /** @var Client Network zone instance */
     public $nz;
 
@@ -204,6 +207,20 @@ class Client
     }
 
     /**
+     * Set the default language for the API.
+     *
+     * @param string $lang The language
+     *
+     * @return $this
+     */
+    public function setLang($lang)
+    {
+        $this->lang = $lang;
+
+        return $this;
+    }
+
+    /**
      * Set the Alma region code ('na' for North America, 'eu' for Europe, 'ap' for Asia Pacific).
      *
      * @param $regionCode
@@ -238,6 +255,7 @@ class Client
             $query = array_merge($query0, $query);
         }
         $query['apikey'] = $this->key;
+        $query['lang'] = $this->lang;
 
         $url = $url[0];
 


### PR DESCRIPTION
Following issue #22 and having the same need, here is a PR that adds an option to set the lang in the client.

As I didn't want to change the parameters order in ``__construct`` for backward compatibility, I have just added a setLang function to the Client.

And this time @danmichaelo I took time to learn a bit more about phpspec. It might not be the best tests ever, so feel free to update them before merging, I have never used this tool before one hour ago so it's mainly copy/paste.